### PR TITLE
[Fix] GraphQL Type Error 

### DIFF
--- a/src/layouts/blogPostLayout.js
+++ b/src/layouts/blogPostLayout.js
@@ -156,8 +156,8 @@ export const query = graphql`
       frontmatter {
         title
         heroImage {
-          alt
           src
+          alt
         }
       }
     }


### PR DESCRIPTION
### Description:

Fixing GraphQL type error on load
### Error: 
![CleanShot 2022-07-05 at 14 55 12@2x](https://user-images.githubusercontent.com/30577676/177344496-76c88ed5-e08b-4263-9bda-92a8cde8db98.png)

### Fix:
![CleanShot 2022-07-05 at 14 56 03](https://user-images.githubusercontent.com/30577676/177344817-9d22af36-8fea-4cbb-b365-6850683a8a0b.png)

**1.** `src` here has an object within it
**2.** In the blog post markdown files, it looks like `heroImage` is only expecting `alt` and `src` as a string

### After: 

Page now loads without error

![CleanShot 2022-07-05 at 15 02 09@2x](https://user-images.githubusercontent.com/30577676/177345932-e6917ca5-72d7-4ca0-8575-8498a7d4e01f.png)





